### PR TITLE
Fixed overflow scroll bar in Firefox

### DIFF
--- a/common/css/main.css
+++ b/common/css/main.css
@@ -35,7 +35,7 @@ body {
 	max-height: 85%;
 	overflow: auto;
 	display: flex;
-	overflow-y: scroll;
+	overflow-y: auto;
 }
 
 #wrapper a {


### PR DESCRIPTION
Changing the overflow-y to auto to keep the scroll bar from showing up in Firefox.