### PR TITLE
Add docker images, push to temp registry and update docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:stable
+
+COPY ./index.html /usr/share/nginx/html/index.html
+COPY ./favicon.ico /usr/share/nginx/html/
+ADD ./common/ /usr/share/nginx/html/common

--- a/README.md
+++ b/README.md
@@ -19,5 +19,14 @@ This project uses:
 ## To Use
 Copy the config.sample.json file and rename to config.json. Be sure to update the fields as you see appropriate.
 
+## Docker
+
+Docker images based on nginx are pushed to docker hub as
+[olifant/simple-dash](https://hub.docker.com/r/olifant/simple-dash). Run the container by mounting a config file from
+the host  and expose the necessary ports.
+
+    $ docker pull olifant/simple-dash:latest
+    $ docker run -p 8080:80 -v $(pwd)/config.json:/usr/share/nginx/html/config.json olifant/simple-dash:latest
+
 ## Configure Homepage
 - 'items' => The menu will scale to the amount of items you want to display. Insert any link you'd like, or {{cur}} for the current URL of the page. Choose icons from [Font Awesome](http://fontawesome.io/icons/)


### PR DESCRIPTION
The images are built with multi platform support like this:

    $ docker buildx create --name mybuilder --use
    $ docker buildx  build --push --platform linux/arm64,linux/amd64  -t olifant/simple-dash:latest .

The images require the user to mount a config file just as usual.